### PR TITLE
[#3] 通知スケジュールの矛盾修正とカスタマイズ対応

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,7 +1,8 @@
 /**
  * Blog-Read-Forced — Service Worker (background.js)
  *
- * 毎日12:00に未読記事をランダム取得してデスクトップ通知を表示する。
+ * 設定された間隔（デフォルト60分）で未読記事を登録日が古い順で取得し、
+ * デスクトップにポップアップ通知を表示する。
  * 通知クリック時に記事URLを新しいタブで開く。
  */
 
@@ -10,6 +11,12 @@ const ALARM_NAME = "daily-article";
 
 /** @type {string} ストレージキー: GAS WebアプリURL */
 const STORAGE_KEY_GAS_URL = "gasUrl";
+
+/** @type {string} ストレージキー: 通知間隔（分） */
+const STORAGE_KEY_INTERVAL = "notifyIntervalMinutes";
+
+/** @type {number} デフォルトの通知間隔（分） */
+const DEFAULT_INTERVAL_MINUTES = 60;
 
 /** @type {string} 通知IDのプレフィックス */
 const NOTIFICATION_ID = "blog-read-forced";
@@ -22,6 +29,31 @@ const NOTIFICATION_ID = "blog-read-forced";
 async function getGasUrl() {
   const result = await chrome.storage.local.get(STORAGE_KEY_GAS_URL);
   return result[STORAGE_KEY_GAS_URL] || null;
+}
+
+/**
+ * chrome.storage.local から通知間隔（分）を取得する。
+ *
+ * @returns {Promise<number>} 通知間隔（分）。未設定の場合はデフォルト値
+ */
+async function getIntervalMinutes() {
+  const result = await chrome.storage.local.get(STORAGE_KEY_INTERVAL);
+  return result[STORAGE_KEY_INTERVAL] || DEFAULT_INTERVAL_MINUTES;
+}
+
+/**
+ * 指定した間隔でアラームを（再）登録する。
+ * 既存のアラームがあれば削除してから作り直す。
+ *
+ * @param {number} intervalMinutes - 通知間隔（分）
+ */
+async function registerAlarm(intervalMinutes) {
+  await chrome.alarms.clear(ALARM_NAME);
+  chrome.alarms.create(ALARM_NAME, {
+    delayInMinutes: 1,
+    periodInMinutes: intervalMinutes,
+  });
+  console.info(`[Blog-Read-Forced] 通知間隔を ${intervalMinutes} 分に設定しました。`);
 }
 
 /**
@@ -90,16 +122,22 @@ async function onAlarm() {
 
 /**
  * 拡張インストール / アップデート時にアラームを登録する。
- * periodInMinutes: 1440 = 24時間ごとに発火。
+ * ユーザーが設定した間隔（デフォルト60分）で通知を繰り返す。
  */
-chrome.runtime.onInstalled.addListener(() => {
-  chrome.alarms.create(ALARM_NAME, {
-    delayInMinutes: 1,
-    periodInMinutes: 180, // 3時間ごと
-  });
-  console.info("[Blog-Read-Forced] 3時間ごとに通知します。");
+chrome.runtime.onInstalled.addListener(async () => {
+  const interval = await getIntervalMinutes();
+  await registerAlarm(interval);
 });
 
+/**
+ * ポップアップから通知間隔が変更されたときにアラームを再登録する。
+ */
+chrome.storage.onChanged.addListener(async (changes, area) => {
+  if (area === "local" && changes[STORAGE_KEY_INTERVAL]) {
+    const newInterval = changes[STORAGE_KEY_INTERVAL].newValue || DEFAULT_INTERVAL_MINUTES;
+    await registerAlarm(newInterval);
+  }
+});
 /**
  * アラーム発火時のリスナー。
  */
@@ -135,19 +173,3 @@ chrome.notifications.onClicked.addListener(async (notificationId) => {
   }
 });
 
-// ── ユーティリティ ────────────────────────────────────────
-
-/**
- * 次の12:00 (正午) の Unix タイムスタンプ (ms) を返す。
- * 現在時刻がすでに12:00を過ぎていれば翌日の12:00を返す。
- *
- * @returns {number}
- */
-function getNextNoonTimestamp() {
-  const now = new Date();
-  const noon = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 12, 0, 0, 0);
-  if (noon <= now) {
-    noon.setDate(noon.getDate() + 1);
-  }
-  return noon.getTime();
-}

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Blog-Read-Forced",
   "version": "1.0.0",
-  "description": "保存した記事を毎日12時に通知して強制的に読む習慣を作るツール",
+  "description": "保存した記事を定期的に通知して強制的に読む習慣を作るツール。通知間隔はカスタマイズ可能（デフォルト1時間）",
   "permissions": [
     "alarms",
     "notifications",

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -54,6 +54,21 @@
       border-color: #4285f4;
     }
 
+    #interval-select {
+      width: 100%;
+      padding: 8px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-size: 13px;
+      background: #fff;
+      outline: none;
+      cursor: pointer;
+    }
+
+    #interval-select:focus {
+      border-color: #4285f4;
+    }
+
     /* ボタン共通 */
     button {
       width: 100%;
@@ -156,6 +171,18 @@
       />
       <br /><br />
       <button id="save-url-btn">URL を保存</button>
+    </div>
+
+    <!-- 通知間隔設定 -->
+    <div>
+      <div class="section-label">通知間隔</div>
+      <select id="interval-select">
+        <option value="60">1時間ごと</option>
+        <option value="180">3時間ごと</option>
+        <option value="360">6時間ごと</option>
+        <option value="720">12時間ごと</option>
+        <option value="1440">24時間ごと</option>
+      </select>
     </div>
 
     <hr />

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -7,7 +7,10 @@
  */
 
 /** @type {string} ストレージキー: GAS WebアプリURL */
-const STORAGE_KEY_GAS_URL = "gasUrl"; 
+const STORAGE_KEY_GAS_URL = "gasUrl";
+
+/** @type {string} ストレージキー: 通知間隔（分） */
+const STORAGE_KEY_INTERVAL = "notifyIntervalMinutes";
 
 /** @type {HTMLInputElement} */
 const gasUrlInput = /** @type {HTMLInputElement} */ (document.getElementById("gas-url-input"));
@@ -29,6 +32,9 @@ const articleTitle = /** @type {HTMLAnchorElement} */ (document.getElementById("
 
 /** @type {HTMLElement} */
 const articleEmpty = /** @type {HTMLElement} */ (document.getElementById("article-empty"));
+
+/** @type {HTMLSelectElement} */
+const intervalSelect = /** @type {HTMLSelectElement} */ (document.getElementById("interval-select"));
 
 // ── ユーティリティ ────────────────────────────────────────
 
@@ -79,15 +85,20 @@ async function loadOldestArticle(gasUrl) {
 }
 
 /**
- * ポップアップ表示時に保存済み GAS URL をインプットに反映し、未読記事を取得する。
+ * ポップアップ表示時に保存済みの設定を反映し、未読記事を取得する。
  */
 async function init() {
-  const result = await chrome.storage.local.get(STORAGE_KEY_GAS_URL);
+  const result = await chrome.storage.local.get([STORAGE_KEY_GAS_URL, STORAGE_KEY_INTERVAL]);
   const gasUrl = result[STORAGE_KEY_GAS_URL];
+  const interval = result[STORAGE_KEY_INTERVAL];
+
   if (gasUrl) {
     gasUrlInput.value = gasUrl;
     await loadOldestArticle(gasUrl);
   }
+
+  // 保存済みの通知間隔をセレクトボックスに反映（未設定時はデフォルト60分）
+  intervalSelect.value = String(interval || 60);
 }
 
 // ── イベントハンドラ ─────────────────────────────────────
@@ -113,6 +124,17 @@ saveUrlBtn.addEventListener("click", async () => {
   } finally {
     setDisabled(saveUrlBtn, false);
   }
+});
+
+/**
+ * 通知間隔セレクトボックスの変更ハンドラ。
+ * 選択値を chrome.storage.local に保存する。
+ * background.js が storage.onChanged で検知してアラームを再登録する。
+ */
+intervalSelect.addEventListener("change", async () => {
+  const minutes = Number(intervalSelect.value);
+  await chrome.storage.local.set({ [STORAGE_KEY_INTERVAL]: minutes });
+  showMessage(`通知間隔を変更しました`, "success");
 });
 
 /**


### PR DESCRIPTION
## Summary
  - manifest/コード/コメント間の通知間隔の記述矛盾を修正
  - ポップアップに通知間隔セレクトボックス（1h/3h/6h/12h/24h）を追加
  - 未使用の getNextNoonTimestamp() を削除

  ## Related Issue
  Closes #3

  ## Changes
  - background.js: アラーム登録をカスタマイズ可能に、storage.onChanged で間隔変更を検知
  - manifest.json: description を実態に合わせて修正
  - popup.html: 通知間隔セレクトボックスUI追加
  - popup.js: 間隔の読み込み・保存ロジック追加

  ## Test Plan
  - 拡張をリロード後、ポップアップで間隔を変更して設定が保存されるか確認
  - Service Worker のコンソールログで間隔変更が反映されるか確認