### PR TITLE
[#7] UIビジュアルフィードバック改善

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,6 @@
+{
+  "enabledMcpjsonServers": [
+    "notion"
+  ],
+  "enableAllProjectMcpServers": true
+}

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -21,6 +21,18 @@ const DEFAULT_INTERVAL_MINUTES = 60;
 /** @type {string} 通知IDのプレフィックス */
 const NOTIFICATION_ID = "blog-read-forced";
 
+/** @type {string} 警告通知用のID */
+const WARNING_NOTIFICATION_ID = "blog-read-forced-warning";
+
+/** @type {string} ストレージキー: 最終通知日時 */
+const STORAGE_KEY_LAST_NOTIFIED = "lastNotifiedAt";
+
+/** @type {string} ストレージキー: GAS URL未設定の警告済みフラグ */
+const STORAGE_KEY_WARNED_NO_URL = "warnedNoUrl";
+
+/** @type {string} テスト通知用のID（既読処理をスキップするため分離） */
+const TEST_NOTIFICATION_ID = "blog-read-forced-test";
+
 /**
  * chrome.storage.local から GAS の URL を取得する。
  *
@@ -71,7 +83,7 @@ async function fetchRandomArticle(gasUrl) {
 }
 
 /**
- * デスクトップ通知を表示する。
+ * デスクトップ通知を表示し、最終通知日時を記録する。
  * 通知クリック時に開けるよう articleUrl を保持する。
  *
  * @param {string} title - 通知に表示する記事タイトル
@@ -79,15 +91,36 @@ async function fetchRandomArticle(gasUrl) {
  */
 function showNotification(title, articleUrl) {
   // クリック時に URL を参照できるよう storage に保存
-  chrome.storage.local.set({ pendingArticleUrl: articleUrl });
+  chrome.storage.local.set({
+    pendingArticleUrl: articleUrl,
+    [STORAGE_KEY_LAST_NOTIFIED]: new Date().toISOString(),
+  });
+
+  // 記事タイトルを通知タイトルに使用（40文字で省略）
+  const displayTitle = title.length > 40 ? title.slice(0, 40) + "…" : title;
 
   chrome.notifications.create(NOTIFICATION_ID, {
     type: "basic",
     iconUrl: "icon128.png",
-    title: "今日の記事",
-    message: title,
+    title: displayTitle,
+    message: "Blog-Read-Forced",
     contextMessage: "クリックして読む",
     requireInteraction: true,
+  });
+}
+
+/**
+ * 警告用のデスクトップ通知を表示する。
+ *
+ * @param {string} title - 警告タイトル
+ * @param {string} message - 警告メッセージ
+ */
+function showWarningNotification(title, message) {
+  chrome.notifications.create(WARNING_NOTIFICATION_ID, {
+    type: "basic",
+    iconUrl: "icon128.png",
+    title,
+    message,
   });
 }
 
@@ -98,7 +131,17 @@ function showNotification(title, articleUrl) {
 async function onAlarm() {
   const gasUrl = await getGasUrl();
   if (!gasUrl) {
-    console.warn("[Blog-Read-Forced] GAS URL が設定されていません。popup から設定してください。");
+    // 初回のみ警告通知を表示し、以降はログのみ
+    const { [STORAGE_KEY_WARNED_NO_URL]: alreadyWarned } =
+      await chrome.storage.local.get(STORAGE_KEY_WARNED_NO_URL);
+    if (!alreadyWarned) {
+      showWarningNotification(
+        "設定が必要です",
+        "GAS URL が未設定です。拡張アイコンをクリックして設定してください。"
+      );
+      await chrome.storage.local.set({ [STORAGE_KEY_WARNED_NO_URL]: true });
+    }
+    console.warn("[Blog-Read-Forced] GAS URL が設定されていません。");
     return;
   }
 
@@ -115,6 +158,10 @@ async function onAlarm() {
     }
   } catch (err) {
     console.error("[Blog-Read-Forced] 記事取得に失敗しました:", err);
+    showWarningNotification(
+      "記事取得に失敗",
+      "GAS への接続に失敗しました。URLが正しいか、ネットワークを確認してください。"
+    );
   }
 }
 
@@ -133,9 +180,16 @@ chrome.runtime.onInstalled.addListener(async () => {
  * ポップアップから通知間隔が変更されたときにアラームを再登録する。
  */
 chrome.storage.onChanged.addListener(async (changes, area) => {
-  if (area === "local" && changes[STORAGE_KEY_INTERVAL]) {
+  if (area !== "local") return;
+
+  if (changes[STORAGE_KEY_INTERVAL]) {
     const newInterval = changes[STORAGE_KEY_INTERVAL].newValue || DEFAULT_INTERVAL_MINUTES;
     await registerAlarm(newInterval);
+  }
+
+  // GAS URL が設定されたら警告フラグをリセット
+  if (changes[STORAGE_KEY_GAS_URL] && changes[STORAGE_KEY_GAS_URL].newValue) {
+    await chrome.storage.local.remove(STORAGE_KEY_WARNED_NO_URL);
   }
 });
 /**
@@ -145,6 +199,46 @@ chrome.alarms.onAlarm.addListener((alarm) => {
   if (alarm.name === ALARM_NAME) {
     onAlarm();
   }
+});
+
+/**
+ * ポップアップからの「テスト通知」リクエストを処理する。
+ * GAS から未読記事を取得し、テスト通知を表示する（既読にはしない）。
+ */
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message.type !== "testNotification") return false;
+
+  (async () => {
+    const gasUrl = await getGasUrl();
+    if (!gasUrl) {
+      sendResponse({ success: false, error: "GAS URL が設定されていません" });
+      return;
+    }
+
+    try {
+      const data = await fetchRandomArticle(gasUrl);
+      if (data.status === "empty") {
+        sendResponse({ success: false, error: "未読記事がありません" });
+        return;
+      }
+
+      if (data.status === "ok" && data.url) {
+        chrome.notifications.create(TEST_NOTIFICATION_ID, {
+          type: "basic",
+          iconUrl: "icon128.png",
+          title: "テスト通知",
+          message: data.title || data.url,
+          contextMessage: "これはテスト通知です（既読になりません）",
+        });
+        sendResponse({ success: true });
+      }
+    } catch (err) {
+      sendResponse({ success: false, error: "GAS への接続に失敗しました" });
+    }
+  })();
+
+  // 非同期レスポンスのため true を返す
+  return true;
 });
 
 /**

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -90,6 +90,30 @@
       cursor: not-allowed;
     }
 
+    /* ローディングスピナー */
+    .btn-loading {
+      position: relative;
+      color: transparent !important;
+    }
+
+    .btn-loading::after {
+      content: "";
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 16px;
+      height: 16px;
+      margin: -8px 0 0 -8px;
+      border: 2px solid rgba(255, 255, 255, 0.3);
+      border-top-color: #fff;
+      border-radius: 50%;
+      animation: spin 0.6s linear infinite;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+
     #save-url-btn {
       background: #34a853;
       color: #fff;
@@ -116,6 +140,11 @@
 
     #message.error {
       color: #ea4335;
+    }
+
+    #message.fade-out {
+      transition: opacity 0.5s;
+      opacity: 0;
     }
 
     hr {
@@ -156,6 +185,118 @@
       color: #888;
       text-align: center;
     }
+
+    .status-info {
+      font-size: 11px;
+      color: #999;
+      text-align: center;
+    }
+
+    /* ヘルプボタン */
+    .label-row {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 4px;
+    }
+
+    #help-btn {
+      width: 18px;
+      height: 18px;
+      padding: 0;
+      border: 1px solid #ccc;
+      border-radius: 50%;
+      background: #fff;
+      color: #888;
+      font-size: 11px;
+      font-weight: bold;
+      cursor: pointer;
+      line-height: 16px;
+      text-align: center;
+      flex-shrink: 0;
+    }
+
+    #help-btn:hover {
+      background: #4285f4;
+      color: #fff;
+      border-color: #4285f4;
+    }
+
+    /* ヘルプモーダル */
+    .modal-overlay {
+      display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0, 0, 0, 0.5);
+      z-index: 10;
+    }
+
+    .modal-content {
+      background: #fff;
+      border-radius: 8px;
+      padding: 16px;
+      margin: 20px 10px;
+      max-height: calc(100% - 40px);
+      overflow-y: auto;
+      font-size: 12px;
+      line-height: 1.6;
+    }
+
+    .modal-content h3 {
+      font-size: 14px;
+      margin-bottom: 8px;
+      color: #333;
+    }
+
+    .modal-content ol {
+      padding-left: 20px;
+      margin-bottom: 12px;
+    }
+
+    .modal-content li {
+      margin-bottom: 4px;
+    }
+
+    .modal-content code {
+      background: #f0f0f0;
+      padding: 1px 4px;
+      border-radius: 3px;
+      font-size: 11px;
+    }
+
+    #modal-close-btn {
+      width: 100%;
+      padding: 8px;
+      font-size: 13px;
+    }
+
+    /* 未読件数バッジ */
+    .unread-badge {
+      font-size: 12px;
+      font-weight: bold;
+      color: #4285f4;
+      text-align: center;
+      padding: 4px 0;
+    }
+
+    /* スキップボタン */
+    #skip-btn {
+      background: #f44336;
+      color: #fff;
+      font-size: 12px;
+      padding: 7px;
+    }
+
+    /* テスト通知ボタン */
+    #test-notify-btn {
+      background: #ff9800;
+      color: #fff;
+      font-size: 12px;
+      padding: 7px;
+    }
   </style>
 </head>
 <body>
@@ -163,7 +304,10 @@
   <main>
     <!-- GAS URL 設定 -->
     <div>
-      <div class="section-label">GAS ウェブアプリ URL</div>
+      <div class="label-row">
+        <div class="section-label" style="margin-bottom:0;">GAS ウェブアプリ URL</div>
+        <button id="help-btn" title="セットアップガイドを表示">?</button>
+      </div>
       <input
         id="gas-url-input"
         type="url"
@@ -187,11 +331,15 @@
 
     <hr />
 
+    <!-- 未読件数 -->
+    <div id="unread-count" class="unread-badge" style="display:none;"></div>
+
     <!-- 未読記事表示 -->
     <div id="article-card" style="display:none;">
       <div class="card-label">今読むべき記事（最古の未読）</div>
       <a id="article-title" href="#" target="_blank"></a>
     </div>
+    <button id="skip-btn" style="display:none;">この記事をスキップ</button>
     <div id="article-empty" style="display:none;">未読記事はありません</div>
 
     <hr />
@@ -201,7 +349,31 @@
 
     <!-- フィードバックメッセージ -->
     <div id="message"></div>
+
+    <!-- テスト通知 -->
+    <button id="test-notify-btn">テスト通知を送信</button>
+
+    <!-- 診断ステータス -->
+    <div id="last-notified" class="status-info"></div>
   </main>
+
+  <!-- ヘルプモーダル -->
+  <div id="help-modal" class="modal-overlay">
+    <div class="modal-content">
+      <h3>GAS URL のセットアップ方法</h3>
+      <ol>
+        <li>Google ドライブで<strong>新しいスプレッドシート</strong>を作成</li>
+        <li>メニュー「拡張機能」→「Apps Script」を開く</li>
+        <li>エディタに <code>Code.gs</code> の内容を貼り付けて保存</li>
+        <li>「デプロイ」→「新しいデプロイ」をクリック</li>
+        <li>種類: <strong>ウェブアプリ</strong> / 実行ユーザー: <strong>自分</strong> / アクセス: <strong>全員</strong></li>
+        <li>表示された <strong>ウェブアプリ URL</strong> をコピー</li>
+        <li>この画面の入力欄に貼り付けて「URL を保存」</li>
+      </ol>
+      <p>保存後「テスト通知を送信」で動作確認できます。</p>
+      <button id="modal-close-btn">閉じる</button>
+    </div>
+  </div>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -12,6 +12,9 @@ const STORAGE_KEY_GAS_URL = "gasUrl";
 /** @type {string} ストレージキー: 通知間隔（分） */
 const STORAGE_KEY_INTERVAL = "notifyIntervalMinutes";
 
+/** @type {string} ストレージキー: 最終通知日時 */
+const STORAGE_KEY_LAST_NOTIFIED = "lastNotifiedAt";
+
 /** @type {HTMLInputElement} */
 const gasUrlInput = /** @type {HTMLInputElement} */ (document.getElementById("gas-url-input"));
 
@@ -36,17 +39,37 @@ const articleEmpty = /** @type {HTMLElement} */ (document.getElementById("articl
 /** @type {HTMLSelectElement} */
 const intervalSelect = /** @type {HTMLSelectElement} */ (document.getElementById("interval-select"));
 
+/** @type {HTMLElement} */
+const lastNotifiedEl = /** @type {HTMLElement} */ (document.getElementById("last-notified"));
+
+/** @type {HTMLElement} */
+const unreadCountEl = /** @type {HTMLElement} */ (document.getElementById("unread-count"));
+
+/** @type {HTMLButtonElement} */
+const skipBtn = /** @type {HTMLButtonElement} */ (document.getElementById("skip-btn"));
+
+/** @type {HTMLButtonElement} */
+const helpBtn = /** @type {HTMLButtonElement} */ (document.getElementById("help-btn"));
+
+/** @type {HTMLElement} */
+const helpModal = /** @type {HTMLElement} */ (document.getElementById("help-modal"));
+
+/** @type {HTMLButtonElement} */
+const modalCloseBtn = /** @type {HTMLButtonElement} */ (document.getElementById("modal-close-btn"));
+
+/** @type {HTMLButtonElement} */
+const testNotifyBtn = /** @type {HTMLButtonElement} */ (document.getElementById("test-notify-btn"));
+
 // ── ユーティリティ ────────────────────────────────────────
 
 /**
- * メッセージ欄にテキストを表示する。
+ * メッセージ欄にテキストを表示する（showMessageWithFade へのエイリアス）。
  *
  * @param {string} text - 表示するメッセージ
  * @param {"success"|"error"|""} type - スタイルクラス
  */
 function showMessage(text, type = "") {
-  messageEl.textContent = text;
-  messageEl.className = type;
+  showMessageWithFade(text, type);
 }
 
 /**
@@ -57,6 +80,43 @@ function showMessage(text, type = "") {
  */
 function setDisabled(btn, disabled) {
   btn.disabled = disabled;
+}
+
+/**
+ * ボタンにローディングスピナーを表示 / 解除する。
+ *
+ * @param {HTMLButtonElement} btn
+ * @param {boolean} loading
+ */
+function setLoading(btn, loading) {
+  btn.disabled = loading;
+  if (loading) {
+    btn.classList.add("btn-loading");
+  } else {
+    btn.classList.remove("btn-loading");
+  }
+}
+
+/** @type {number|undefined} メッセージフェードアウト用タイマーID */
+let fadeTimer;
+
+/**
+ * メッセージ欄にテキストを表示し、成功メッセージは2秒後に自動フェードアウトする。
+ *
+ * @param {string} text - 表示するメッセージ
+ * @param {"success"|"error"|""} type - スタイルクラス
+ */
+function showMessageWithFade(text, type = "") {
+  clearTimeout(fadeTimer);
+  messageEl.textContent = text;
+  messageEl.className = type;
+  messageEl.classList.remove("fade-out");
+
+  if (type === "success") {
+    fadeTimer = setTimeout(() => {
+      messageEl.classList.add("fade-out");
+    }, 2000);
+  }
 }
 
 // ── 初期化 ───────────────────────────────────────────────
@@ -76,8 +136,17 @@ async function loadOldestArticle(gasUrl) {
       articleTitle.textContent = data.title || data.url;
       articleTitle.href = data.url;
       articleCard.style.display = "block";
+      skipBtn.style.display = "block";
+
+      // 未読件数を表示
+      if (data.unreadCount != null) {
+        unreadCountEl.textContent = `未読: ${data.unreadCount} 件`;
+        unreadCountEl.style.display = "block";
+      }
     } else {
       articleEmpty.style.display = "block";
+      unreadCountEl.textContent = "未読: 0 件";
+      unreadCountEl.style.display = "block";
     }
   } catch (err) {
     console.error("[Blog-Read-Forced] 記事取得失敗:", err);
@@ -88,9 +157,14 @@ async function loadOldestArticle(gasUrl) {
  * ポップアップ表示時に保存済みの設定を反映し、未読記事を取得する。
  */
 async function init() {
-  const result = await chrome.storage.local.get([STORAGE_KEY_GAS_URL, STORAGE_KEY_INTERVAL]);
+  const result = await chrome.storage.local.get([
+    STORAGE_KEY_GAS_URL,
+    STORAGE_KEY_INTERVAL,
+    STORAGE_KEY_LAST_NOTIFIED,
+  ]);
   const gasUrl = result[STORAGE_KEY_GAS_URL];
   const interval = result[STORAGE_KEY_INTERVAL];
+  const lastNotified = result[STORAGE_KEY_LAST_NOTIFIED];
 
   if (gasUrl) {
     gasUrlInput.value = gasUrl;
@@ -99,6 +173,14 @@ async function init() {
 
   // 保存済みの通知間隔をセレクトボックスに反映（未設定時はデフォルト60分）
   intervalSelect.value = String(interval || 60);
+
+  // 最終通知日時を表示
+  if (lastNotified) {
+    const date = new Date(lastNotified);
+    lastNotifiedEl.textContent = `最終通知: ${date.toLocaleString("ja-JP")}`;
+  } else {
+    lastNotifiedEl.textContent = "最終通知: まだ通知されていません";
+  }
 }
 
 // ── イベントハンドラ ─────────────────────────────────────
@@ -111,6 +193,12 @@ saveUrlBtn.addEventListener("click", async () => {
   const url = gasUrlInput.value.trim();
   if (!url) {
     showMessage("URL を入力してください", "error");
+    return;
+  }
+
+  // GAS URLの形式バリデーション
+  if (!url.startsWith("https://script.google.com/")) {
+    showMessage("GAS URL は https://script.google.com/ で始まる必要があります", "error");
     return;
   }
 
@@ -148,7 +236,7 @@ registerBtn.addEventListener("click", async () => {
     return;
   }
 
-  setDisabled(registerBtn, true);
+  setLoading(registerBtn, true);
   showMessage("登録中...");
 
   try {
@@ -171,20 +259,105 @@ registerBtn.addEventListener("click", async () => {
     });
 
     if (!res.ok) {
-      throw new Error(`HTTP ${res.status}`);
+      const errorMsg =
+        res.status === 403
+          ? "GAS URL が正しくないか、アクセス権限がありません"
+          : res.status === 404
+            ? "GAS URL が見つかりません。デプロイ設定を確認してください"
+            : `サーバーエラー (HTTP ${res.status})`;
+      showMessage(errorMsg, "error");
+      return;
     }
 
     const data = await res.json();
     if (data.status === "ok") {
       showMessage("登録しました！", "success");
+    } else if (data.status === "duplicate") {
+      showMessage("この記事は既に登録されています", "error");
     } else {
       showMessage(`エラー: ${data.message || "不明"}`, "error");
     }
   } catch (err) {
-    showMessage("登録に失敗しました", "error");
+    showMessage("通信に失敗しました。ネットワークを確認してください", "error");
     console.error("[Blog-Read-Forced] POST 失敗:", err);
   } finally {
-    setDisabled(registerBtn, false);
+    setLoading(registerBtn, false);
+  }
+});
+
+/**
+ * 「スキップ」ボタンのクリックハンドラ。
+ * 表示中の未読記事をGASから削除し、次の記事を読み込む。
+ */
+skipBtn.addEventListener("click", async () => {
+  const gasUrl = gasUrlInput.value.trim();
+  const articleUrl = articleTitle.href;
+  if (!gasUrl || !articleUrl || articleUrl === "#") return;
+
+  setLoading(skipBtn, true);
+  showMessage("削除中...");
+
+  try {
+    const deleteUrl = `${gasUrl}?action=delete&url=${encodeURIComponent(articleUrl)}`;
+    const res = await fetch(deleteUrl);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+    const data = await res.json();
+    if (data.status === "ok") {
+      showMessage("記事をスキップしました", "success");
+      // UIをリセットして次の記事を読み込む
+      articleCard.style.display = "none";
+      articleEmpty.style.display = "none";
+      skipBtn.style.display = "none";
+      await loadOldestArticle(gasUrl);
+    } else {
+      showMessage(data.message || "削除に失敗しました", "error");
+    }
+  } catch (err) {
+    showMessage("通信に失敗しました", "error");
+    console.error("[Blog-Read-Forced] 削除失敗:", err);
+  } finally {
+    setLoading(skipBtn, false);
+  }
+});
+
+/**
+ * ヘルプモーダルの表示 / 非表示。
+ */
+helpBtn.addEventListener("click", () => {
+  helpModal.style.display = "block";
+});
+
+modalCloseBtn.addEventListener("click", () => {
+  helpModal.style.display = "none";
+});
+
+helpModal.addEventListener("click", (e) => {
+  if (e.target === helpModal) {
+    helpModal.style.display = "none";
+  }
+});
+
+/**
+ * 「テスト通知を送信」ボタンのクリックハンドラ。
+ * background.js にメッセージを送り、テスト通知を発火させる。
+ */
+testNotifyBtn.addEventListener("click", async () => {
+  setDisabled(testNotifyBtn, true);
+  showMessage("テスト通知を送信中...");
+
+  try {
+    const response = await chrome.runtime.sendMessage({ type: "testNotification" });
+    if (response.success) {
+      showMessage("テスト通知を送信しました", "success");
+    } else {
+      showMessage(response.error || "テスト通知に失敗しました", "error");
+    }
+  } catch (err) {
+    showMessage("テスト通知に失敗しました", "error");
+    console.error("[Blog-Read-Forced] テスト通知失敗:", err);
+  } finally {
+    setDisabled(testNotifyBtn, false);
   }
 });
 

--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -64,6 +64,15 @@ function doPost(e) {
     const source = (data.source || "").trim() || "不明";
 
     const sheet = getSheet();
+
+    // 重複チェック: 同じURLの未読記事が既に存在する場合はスキップ
+    const rows = sheet.getDataRange().getValues();
+    for (let i = 1; i < rows.length; i++) {
+      if (rows[i][1] === url && rows[i][3] === "未読") {
+        return jsonResponse({ status: "duplicate", message: "この記事は既に登録されています" });
+      }
+    }
+
     sheet.appendRow([title, url, new Date(), "未読", "", source]);
 
     return jsonResponse({ status: "ok", message: "保存しました" });
@@ -108,6 +117,25 @@ function doGet(_e) {
     }
   }
 
+  // 記事削除: action=delete&url=... で未読記事を行ごと削除する
+  if (params.action === "delete" && params.url) {
+    try {
+      const sheet = getSheet();
+      const rows = sheet.getDataRange().getValues();
+      const targetUrl = params.url.trim();
+
+      for (let i = 1; i < rows.length; i++) {
+        if (rows[i][1] === targetUrl && rows[i][3] === "未読") {
+          sheet.deleteRow(i + 1);
+          return jsonResponse({ status: "ok", message: "記事を削除しました" });
+        }
+      }
+      return jsonResponse({ status: "notFound", message: "対象記事が見つかりません" });
+    } catch (err) {
+      return jsonResponse({ status: "error", message: err.message });
+    }
+  }
+
   try {
     const sheet = getSheet();
     const rows = sheet.getDataRange().getValues();
@@ -116,7 +144,7 @@ function doGet(_e) {
     const unread = rows.slice(1).filter((row) => row[3] === "未読");
 
     if (unread.length === 0) {
-      return jsonResponse({ status: "empty" });
+      return jsonResponse({ status: "empty", unreadCount: 0 });
     }
 
     // 一番古い（先頭の）未読記事を返す
@@ -126,6 +154,7 @@ function doGet(_e) {
       status: "ok",
       title: picked[0],
       url: picked[1],
+      unreadCount: unread.length,
     });
   } catch (err) {
     return jsonResponse({ status: "error", message: err.message });


### PR DESCRIPTION
## Summary
  - 登録・スキップボタンにCSSスピナーのローディング表示を追加
  - 成功メッセージを2秒後に自動フェードアウト
  - デスクトップ通知のタイトルに記事タイトル（40文字省略版）を使用

  ## Related Issue
  Closes #7

  ## Changes
  - popup.html: .btn-loading スピナー、.fade-out スタイル追加
  - popup.js: setLoading()、showMessageWithFade() 追加
  - background.js: 通知titleに記事タイトル省略版を使用

  ## Test Plan
  - 記事登録ボタンクリック → スピナーが回るか確認
  - 登録成功後 → メッセージが2秒後にフェードアウトするか確認
  - スキップボタンクリック → スピナーが回るか確認
  - デスクトップ通知 → 記事タイトルがtitleに表示されるか確認