### PR TITLE
docs: アーキテクチャMermaid図を実装に合わせて更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,27 +62,60 @@ iPhone で見つけた記事をワンタップで登録。あとは何もしな�
 
 ```mermaid
 flowchart TD
-    subgraph 登録
-        A[iPhone Safari/Chrome] -->|共有ボタン| B[iOS ショートカット]
-        C[Chrome 拡張 popup] -->|クリック| D[現在タブ取得]
-        B -->|POST url,source| GAS
-        D -->|POST url,title,source| GAS
+    %% ── 登録フロー ──────────────────────────
+    subgraph 登録["📥 登録フロー"]
+        IP[iPhone Safari/Chrome] -->|共有ボタン| SC[iOS ショートカット]
+        SC -->|POST url, source| GAS
+        EX[Chrome 拡張ポップアップ] -->|登録ボタン| TAB[現在タブの<br/>URL・タイトル取得]
+        TAB -->|POST url, title, source| GAS
     end
 
-    subgraph バックエンド
-        GAS[Google Apps Script\ndoPost / doGet] --> SS[(Google\nスプレッドシート)]
+    %% ── バックエンド ────────────────────────
+    subgraph バックエンド["🗄 バックエンド GAS"]
+        GAS["Google Apps Script<br/>doPost / doGet"]
+        GAS <-->|読み書き| SS[(Google<br/>スプレッドシート<br/>articles)]
     end
 
-    subgraph 通知
-        BG[Chrome background.js\nService Worker] -->|GET 未読1件| GAS
-        BG -->|chrome.notifications| NOTIF[デスクトップ通知]
-        NOTIF -->|クリック| TAB[記事を新タブで開く]
-
-        BG -->|GET ?action=notifyLine| GAS
+    %% ── 定期通知フロー（メイン）─────────────
+    subgraph 通知["🔔 定期通知フロー"]
+        BG["Chrome background.js<br/>Service Worker<br/>chrome.alarms"]
+        BG -->|GET 最古未読1件| GAS
+        BG -->|chrome.notifications| PCNOTIF[💻 PC デスクトップ通知]
+        BG -->|GET ?action=notifyLine&url=...<br/>※PC通知と同時送信| GAS
         GAS -->|broadcast| LINE[LINE 公式アカウント]
-        LINE -->|メッセージ| PHONE[スマホの LINE]
+        LINE -->|プッシュ通知| PHONE[📱 スマホ LINE]
+
+        PCNOTIF -->|クリック| OPENTAB[記事を新タブで開く]
+        OPENTAB -->|GET ?action=markRead| GAS
+        PHONE -.->|既読リンクをタップ| GAS
     end
+
+    %% ── ポップアップUI（操作系）──────────────
+    subgraph 操作["🎛 ポップアップ UI 操作"]
+        EX -->|表示時| GETONE[GET 最古未読1件]
+        GETONE --> GAS
+        EX -->|スキップボタン| DEL[GET ?action=delete]
+        DEL --> GAS
+        EX -->|テスト通知ボタン| BG
+    end
+
+    classDef gas fill:#fef3c7,stroke:#f59e0b,color:#92400e
+    classDef chrome fill:#dbeafe,stroke:#3b82f6,color:#1e3a8a
+    classDef line fill:#d1fae5,stroke:#10b981,color:#065f46
+    classDef storage fill:#f3e8ff,stroke:#a855f7,color:#581c87
+    class GAS gas
+    class BG,EX,TAB,PCNOTIF,OPENTAB,GETONE,DEL chrome
+    class LINE,PHONE line
+    class SS storage
 ```
+
+### 図の読み方
+
+- **登録フロー**：iPhone のショートカット or Chrome 拡張のボタンから、`doPost` で記事を保存。
+- **定期通知フロー**：Chrome 拡張の `chrome.alarms` で発火し、未読1件取得 → **PC通知と LINE 通知を同時送信** → クリックで記事を開いて自動既読化。
+- **ポップアップ UI**：ポップアップ表示時に最古未読をカード表示。「スキップ」で記事削除、「テスト通知」で background.js にメッセージを送って疑似発火。
+
+> ⚠️ LINE 通知は GAS の時間トリガーではなく **Chrome 拡張の `chrome.alarms` 駆動** です。Chrome を起動していないと通知は飛びません。
 
 ---
 


### PR DESCRIPTION
## Summary
- README.md の `## 🏗 アーキテクチャ` セクションの Mermaid 図を、現在の実装に合わせて全面差し替え
- 追加機能（スキップ・テスト通知・LINE同期送信・既読化動線）を図に反映
- 視認性向上のため subgraph を 3→4 に拡張、classDef でカラーリング

## Related Issue
特定の issue に紐付かないドキュメント整備（実装と図のズレ解消）

## Changes
- `README.md`：
  - Mermaid 図の全面差し替え
  - subgraph を「登録 / バックエンド / 定期通知 / 操作系」の4分割に
  - スキップ機能（`?action=delete`）と既読化（`?action=markRead`）のフローを追加
  - ポップアップ表示時の最古未読取得フローを追加
  - テスト通知ボタン → background.js のメッセージ経路を追加
  - LINE通知の「PC通知と同時送信」をラベルで明示
  - `\n` を `<br/>` に統一、`subgraph ID["表示名"]` 形式に変更
  - GAS=黄、Chrome=青、LINE=緑、DB=紫のカラースキーム
  - 「図の読み方」「LINE通知は Chrome のアラーム駆動」の補足ノートを追加

## Test Plan
- [ ] GitHub 上で README.md を開き、Mermaid 図が崩れず描画されること
- [ ] 全ノード（GAS / BG / EX / LINE / SS など）が classDef で色分けされて表示されること
- [ ] 4 つの subgraph（登録 / バックエンド / 定期通知 / 操作系）が見出し付きで表示されること
- [ ] 図の下の「図の読み方」セクションが表示されること
- [ ] ライト・ダーク両モードで色が極端に潰れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)